### PR TITLE
Alert 및 Dialog 컴포넌트 추가

### DIFF
--- a/apps/docs/src/components/Alert/Alert.docs.mdx
+++ b/apps/docs/src/components/Alert/Alert.docs.mdx
@@ -4,7 +4,10 @@ import { ArgsTable, Canvas, Story, PRIMARY_STORY } from '@storybook/addon-docs';
 
 사용자에 대한 확인 또는 경고를 알리기 위한 컴포넌트
 
-<Canvas withToolbar>
+<Canvas
+  withToolbar
+  mdxSource={`<Alert.Root>\n\t<Alert.Trigger/>\n\t<Alert.Content />\n</Alert.Root>`}
+>
   <Story id="components-alert--base" />
 </Canvas>
 

--- a/apps/docs/src/components/Alert/Alert.docs.mdx
+++ b/apps/docs/src/components/Alert/Alert.docs.mdx
@@ -1,0 +1,11 @@
+import { ArgsTable, Canvas, Story, PRIMARY_STORY } from '@storybook/addon-docs';
+
+# Alert
+
+사용자에 대한 확인 또는 경고를 알리기 위한 컴포넌트
+
+<Canvas withToolbar>
+  <Story id="components-alert--base" />
+</Canvas>
+
+<ArgsTable story={PRIMARY_STORY} />

--- a/apps/docs/src/components/Alert/Alert.stories.tsx
+++ b/apps/docs/src/components/Alert/Alert.stories.tsx
@@ -1,0 +1,38 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { Alert, Button } from '@triprint/ui';
+
+import { actionArgType, stringArgType } from '../../utils';
+import docs from './Alert.docs.mdx';
+
+export default {
+  title: 'Components/Alert',
+  component: Alert,
+  argTypes: {
+    title: stringArgType('제목', ['ReactNode', 'string']),
+    description: stringArgType('설명', ['ReactNode', 'string']),
+    actionLabel: stringArgType('실행 버튼 `label`', ['ReactNode', 'string'], '확인'),
+    cancelLabel: stringArgType('취소 버튼 `label`', ['ReactNode', 'string'], '취소'),
+    onAction: actionArgType('onAction', '확인(actionLabel) 버튼을 클릭했을 때의 Event Handler'),
+  },
+  parameters: {
+    docs: {
+      page: docs,
+    },
+  },
+} as ComponentMeta<typeof Alert>;
+
+export const Base: ComponentStory<typeof Alert> = ({ ...args }) => {
+  return (
+    <Alert.Root>
+      <Alert.Trigger asChild>
+        <Button>로그아웃</Button>
+      </Alert.Trigger>
+      <Alert {...args} />
+    </Alert.Root>
+  );
+};
+Base.args = {
+  title: '로그아웃',
+  description: '정말 로그아웃 하시겠나요?',
+};

--- a/apps/docs/src/components/Alert/Alert.stories.tsx
+++ b/apps/docs/src/components/Alert/Alert.stories.tsx
@@ -7,7 +7,7 @@ import docs from './Alert.docs.mdx';
 
 export default {
   title: 'Components/Alert',
-  component: Alert,
+  component: Alert.Content,
   argTypes: {
     title: stringArgType('제목', ['ReactNode', 'string']),
     description: stringArgType('설명', ['ReactNode', 'string']),
@@ -20,15 +20,15 @@ export default {
       page: docs,
     },
   },
-} as ComponentMeta<typeof Alert>;
+} as ComponentMeta<typeof Alert.Content>;
 
-export const Base: ComponentStory<typeof Alert> = ({ ...args }) => {
+export const Base: ComponentStory<typeof Alert.Content> = ({ ...args }) => {
   return (
     <Alert.Root>
       <Alert.Trigger asChild>
         <Button>로그아웃</Button>
       </Alert.Trigger>
-      <Alert {...args} />
+      <Alert.Content {...args} />
     </Alert.Root>
   );
 };

--- a/apps/docs/src/components/Dialog/Dialog.docs.mdx
+++ b/apps/docs/src/components/Dialog/Dialog.docs.mdx
@@ -1,0 +1,68 @@
+import { ArgsTable, Canvas, Story, PRIMARY_STORY, Source } from '@storybook/addon-docs';
+
+# Dialog
+
+모달 형식의 컨텐츠를 보여주는 컴포넌트
+
+<Canvas withToolbar withSource="none">
+  <Story id="components-dialog--base" />
+</Canvas>
+
+<ArgsTable story={PRIMARY_STORY} />
+
+## 구조
+
+<Source
+  language="tsx"
+  format={true}
+  code={`<Dialog.Root>
+    <DialogTrigger />
+    <Dialog.Content>
+      <Dialog.Close />
+    </Dialog.Content>
+  </Dialog.Root>`}
+/>
+
+## 크기
+
+- **xs**: 320px
+- **sm**: 384px
+- **md**: 448px
+- **lg(default)**: 512px
+- **xl**: 576px
+- **2xl**: 672px
+- **3xl**: 768px
+- **4xl**: 896px
+- **5xl**: 1024px
+- **6xl**: 1152px
+- **7xl**: 1280px
+
+<Canvas withSource="none">
+  <Story id="components-dialog--size" />
+</Canvas>
+
+## 전체화면
+
+모달을 전체화면으로 보여주고 싶은 경우에 옵션
+
+**참조**
+
+- `height`와 `paddingX` 그리고 `borderRadius`가 없어짐
+- size는 주어진 옵션대로 적용이 됨 (`maxWidth`)
+
+<Canvas withSource="none">
+  <Story id="components-dialog--full-screen" />
+</Canvas>
+
+### 예제 코드
+
+<Source
+  language="tsx"
+  format={true}
+  code={`<Dialog.Root>
+    <Dialog.Trigger />
+    <Dialog.Content
+      fullScreen={{ '@initial': true, '@tablet': false }}
+    />
+  </Dialog.Root>`}
+/>

--- a/apps/docs/src/components/Dialog/Dialog.stories.tsx
+++ b/apps/docs/src/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,116 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { Button, Dialog, Flex } from '@triprint/ui';
+
+import { booleanArgType, childrenArgType, selectArgType, stringArgType } from '../../utils';
+import docs from './Dialog.docs.mdx';
+
+export default {
+  title: 'Components/Dialog',
+  component: Dialog.Content,
+  argTypes: {
+    children: childrenArgType('Dialog 내용'),
+    title: stringArgType('Dialog 제목', ['ReactNode']),
+    size: selectArgType(
+      'Dialog maxWidth 크기',
+      ['xs', 'sm', 'md', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl', '7xl'],
+      'lg',
+    ),
+    fullScreen: booleanArgType('전체화면 모달 사용여부', false),
+  },
+  parameters: {
+    docs: {
+      page: docs,
+    },
+  },
+} as ComponentMeta<typeof Dialog.Content>;
+
+const sampleText =
+  '그들의 살았으며, 얼음에 칼이다. 같은 굳세게 얼마나 길지 구하지 인간의 피는 이상은 이것이다. 굳세게 착목한는 아니한 보라. 내려온 용감하고 동산에는 사람은 때문이다. 우리 구하지 가치를 풍부하게 인간의 약동하다. 곳이 역사를 있는 주는 위하여서. 인생을 보내는 사랑의 역사를 얼마나 것이다. 거친 트고, 유소년에게서 그들을 주는 하여도 황금시대의 뿐이다. 원대하고, 그들의 방황하여도, 이상은 든 그것은 품에 소리다.이것은 칼이다.';
+
+export const Base: ComponentStory<typeof Dialog.Content> = ({ ...args }) => {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <Button>Open Dialog</Button>
+      </Dialog.Trigger>
+      <Dialog.Content {...args} />
+    </Dialog.Root>
+  );
+};
+Base.args = {
+  title: '제목',
+  size: 'lg',
+  fullScreen: false,
+  children: sampleText,
+};
+
+type AlertContentSize =
+  | 'xs'
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | '2xl'
+  | '3xl'
+  | '4xl'
+  | '5xl'
+  | '6xl'
+  | '7xl';
+
+export const Size = () => {
+  const sizes: AlertContentSize[] = [
+    'xs',
+    'sm',
+    'md',
+    'lg',
+    'xl',
+    '2xl',
+    '3xl',
+    '4xl',
+    '5xl',
+    '6xl',
+    '7xl',
+  ];
+
+  return (
+    <Flex direction="column" align="center" spacing={6}>
+      <Flex spacing={4}>
+        {sizes.map((size) => (
+          <Dialog.Root key={size}>
+            <Dialog.Trigger asChild>
+              <Button>
+                {size}
+                {size === 'lg' && '(default)'}
+              </Button>
+            </Dialog.Trigger>
+            <Dialog.Content size={size} title="제목">
+              {sampleText}
+            </Dialog.Content>
+          </Dialog.Root>
+        ))}
+      </Flex>
+    </Flex>
+  );
+};
+
+export const FullScreen = () => {
+  return (
+    <Flex direction="column" align="center" spacing={6}>
+      <Flex spacing={4}>
+        <Dialog.Root>
+          <Dialog.Trigger asChild>
+            <Button>Full Screen on Mobile</Button>
+          </Dialog.Trigger>
+          <Dialog.Content
+            title="제목"
+            size="2xl"
+            fullScreen={{ '@initial': true, '@tablet': false }}
+          >
+            {sampleText}
+          </Dialog.Content>
+        </Dialog.Root>
+      </Flex>
+    </Flex>
+  );
+};

--- a/apps/docs/src/utils/argTypes.ts
+++ b/apps/docs/src/utils/argTypes.ts
@@ -48,13 +48,44 @@ export const childrenArgType = (description?: string): InputType => {
 export const numberArgType = (description?: string, defaultValue?: number): InputType => {
   return {
     type: 'number',
-    description: description ?? '자식 컴포넌트 또는 컨텐츠',
+    description,
     defaultValue,
     table: {
       type: {
         summary: 'number',
       },
       defaultValue: { summary: defaultValue },
+    },
+  };
+};
+
+export const stringArgType = (
+  description: string,
+  types = ['string'],
+  defaultValue?: string,
+): InputType => {
+  return {
+    control: 'text',
+    description,
+    defaultValue,
+    table: {
+      type: {
+        summary: types.join(' | '),
+      },
+      defaultValue: { summary: defaultValue },
+    },
+  };
+};
+
+export const actionArgType = (action: string, description?: string, type?: string): InputType => {
+  return {
+    action,
+    description,
+    table: {
+      category: 'Events',
+      type: {
+        summary: type,
+      },
     },
   };
 };

--- a/packages/icons/src/close.svg
+++ b/packages/icons/src/close.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path fill-rule="evenodd" d="M5.47 5.47a.75.75 0 011.06 0L12 10.94l5.47-5.47a.75.75 0 111.06 1.06L13.06 12l5.47 5.47a.75.75 0 11-1.06 1.06L12 13.06l-5.47 5.47a.75.75 0 01-1.06-1.06L10.94 12 5.47 6.53a.75.75 0 010-1.06z" clip-rule="evenodd" />
+</svg>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -29,6 +29,8 @@
     "react-dom": "^18.0.0"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.0.2",
+    "@radix-ui/react-dialog": "^1.0.2",
     "@stitches/react": "^1.2.8",
     "@triprint/icons": "*"
   },

--- a/packages/ui/src/components/Alert/Alert.styled.ts
+++ b/packages/ui/src/components/Alert/Alert.styled.ts
@@ -1,0 +1,41 @@
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import { styled } from 'stitches.config';
+
+import { fadeIn, fadeInAndScaleUp } from '@/styles/keyframes';
+
+export const Overlay = styled(AlertDialog.Overlay, {
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  zIndex: '$modalBackdrop',
+  backgroundColor: 'rgba(0,0,0,0.25)',
+  animation: `${fadeIn} $transitions$150 $transitions$easeIn`,
+});
+
+export const Content = styled(AlertDialog.Content, {
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  padding: '$5',
+  zIndex: '$modal',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  '&:focus': {
+    outline: 'none',
+  },
+});
+
+export const ContentContainer = styled('div', {
+  position: 'relative',
+  width: '$full',
+  maxWidth: '$sm',
+  borderRadius: '$xl',
+  padding: '$5',
+  backgroundColor: '$surface',
+  animation: `${fadeInAndScaleUp} $transitions$150 $transitions$easeIn`,
+});

--- a/packages/ui/src/components/Alert/Alert.styled.ts
+++ b/packages/ui/src/components/Alert/Alert.styled.ts
@@ -3,18 +3,19 @@ import { styled } from 'stitches.config';
 
 import { fadeIn, fadeInAndScaleUp } from '@/styles/keyframes';
 
-export const Overlay = styled(AlertDialog.Overlay, {
+export const StyledAlertOverlay = styled(AlertDialog.Overlay, {
   position: 'fixed',
   top: 0,
   right: 0,
   bottom: 0,
   left: 0,
   zIndex: '$modalBackdrop',
-  backgroundColor: 'rgba(0,0,0,0.25)',
+  backdropFilter: 'blur(4px)',
+  backgroundColor: 'rgba(0,0,0,0.2)',
   animation: `${fadeIn} $transitions$150 $transitions$easeIn`,
 });
 
-export const Content = styled(AlertDialog.Content, {
+export const StyledAlertContent = styled(AlertDialog.Content, {
   position: 'fixed',
   top: 0,
   right: 0,
@@ -30,7 +31,7 @@ export const Content = styled(AlertDialog.Content, {
   },
 });
 
-export const ContentContainer = styled('div', {
+export const StyledAlertContentInner = styled('div', {
   position: 'relative',
   width: '$full',
   maxWidth: '$sm',

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -1,0 +1,58 @@
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import { Flex } from 'layouts';
+import React from 'react';
+
+import { Button } from '../Button';
+import { Text } from '../Text';
+import * as Styled from './Alert.styled';
+
+export interface AlertProps {
+  title: React.ReactNode;
+  description: React.ReactNode;
+  actionLabel?: React.ReactNode;
+  cancelLabel?: React.ReactNode;
+  onAction?: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const Alert = React.forwardRef<React.ElementRef<typeof Styled.Content>, AlertProps>(
+  ({ title, description, actionLabel = '확인', cancelLabel = '취소', onAction }, forwardedRef) => {
+    return (
+      <AlertDialog.Portal>
+        <Styled.Overlay />
+        <Styled.Content ref={forwardedRef}>
+          <Styled.ContentContainer>
+            <AlertDialog.Title asChild>
+              <Text as="h2" weight="bold" size="xl" css={{ marginBottom: '$2' }}>
+                {title}
+              </Text>
+            </AlertDialog.Title>
+            <AlertDialog.Description asChild>
+              <Text as="p" variant="variant" css={{ marginBottom: '$4' }}>
+                {description}
+              </Text>
+            </AlertDialog.Description>
+            <Flex spacingX={4}>
+              <AlertDialog.Action asChild onClick={onAction}>
+                <Button variant="primary" size="lg" fullWidth>
+                  {actionLabel}
+                </Button>
+              </AlertDialog.Action>
+              <AlertDialog.Cancel asChild>
+                <Button size="lg" fullWidth>
+                  {cancelLabel}
+                </Button>
+              </AlertDialog.Cancel>
+            </Flex>
+          </Styled.ContentContainer>
+        </Styled.Content>
+      </AlertDialog.Portal>
+    );
+  },
+);
+
+Alert.displayName = 'Alert';
+
+export default Object.assign(Alert, {
+  Root: AlertDialog.Root,
+  Trigger: AlertDialog.Trigger,
+});

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -1,58 +1,63 @@
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 import { Flex } from 'layouts';
 import React from 'react';
-import { CSSProp } from 'stitches.config';
+import { CSS } from 'stitches.config';
 
 import { Button } from '../Button';
 import { Text } from '../Text';
 import { StyledAlertContent, StyledAlertContentInner, StyledAlertOverlay } from './Alert.styled';
 
-type AlertDialogPrimitivePrimitiveProps = React.ComponentProps<typeof AlertDialogPrimitive.Content>;
-type AlertContentProps = AlertDialogPrimitivePrimitiveProps &
-  CSSProp & {
-    title: React.ReactNode;
-    description: React.ReactNode;
-    actionLabel?: React.ReactNode;
-    cancelLabel?: React.ReactNode;
-    onAction?: React.MouseEventHandler<HTMLButtonElement>;
-  };
+type AlertDialogPrimitiveProps = React.ComponentProps<typeof AlertDialogPrimitive.Content>;
+type AlertContentProps = AlertDialogPrimitiveProps & {
+  title: React.ReactNode;
+  description: React.ReactNode;
+  actionLabel?: React.ReactNode;
+  cancelLabel?: React.ReactNode;
+  onAction?: React.MouseEventHandler<HTMLButtonElement>;
+  css?: CSS;
+};
 
 const AlertContent = React.forwardRef<
   React.ElementRef<typeof StyledAlertContent>,
   AlertContentProps
->(({ title, description, actionLabel = '확인', cancelLabel = '취소', onAction }, forwardedRef) => {
-  return (
-    <AlertDialogPrimitive.Portal>
-      <StyledAlertOverlay />
-      <StyledAlertContent ref={forwardedRef}>
-        <StyledAlertContentInner>
-          <AlertDialogPrimitive.Title asChild>
-            <Text as="h2" weight="bold" size="xl" css={{ marginBottom: '$2' }}>
-              {title}
-            </Text>
-          </AlertDialogPrimitive.Title>
-          <AlertDialogPrimitive.Description asChild>
-            <Text as="p" variant="variant" css={{ marginBottom: '$4' }}>
-              {description}
-            </Text>
-          </AlertDialogPrimitive.Description>
-          <Flex spacingX={4}>
-            <AlertDialogPrimitive.Action asChild onClick={onAction}>
-              <Button variant="primary" size="lg" fullWidth>
-                {actionLabel}
-              </Button>
-            </AlertDialogPrimitive.Action>
-            <AlertDialogPrimitive.Cancel asChild>
-              <Button size="lg" fullWidth>
-                {cancelLabel}
-              </Button>
-            </AlertDialogPrimitive.Cancel>
-          </Flex>
-        </StyledAlertContentInner>
-      </StyledAlertContent>
-    </AlertDialogPrimitive.Portal>
-  );
-});
+>(
+  (
+    { title, description, actionLabel = '확인', cancelLabel = '취소', css, onAction, ...props },
+    forwardedRef,
+  ) => {
+    return (
+      <AlertDialogPrimitive.Portal>
+        <StyledAlertOverlay />
+        <StyledAlertContent ref={forwardedRef} {...props}>
+          <StyledAlertContentInner css={css}>
+            <AlertDialogPrimitive.Title asChild>
+              <Text as="h2" weight="bold" size="xl" css={{ marginBottom: '$2' }}>
+                {title}
+              </Text>
+            </AlertDialogPrimitive.Title>
+            <AlertDialogPrimitive.Description asChild>
+              <Text as="p" variant="variant" css={{ marginBottom: '$4' }}>
+                {description}
+              </Text>
+            </AlertDialogPrimitive.Description>
+            <Flex spacingX={4}>
+              <AlertDialogPrimitive.Action asChild onClick={onAction}>
+                <Button variant="primary" size="lg" fullWidth>
+                  {actionLabel}
+                </Button>
+              </AlertDialogPrimitive.Action>
+              <AlertDialogPrimitive.Cancel asChild>
+                <Button size="lg" fullWidth>
+                  {cancelLabel}
+                </Button>
+              </AlertDialogPrimitive.Cancel>
+            </Flex>
+          </StyledAlertContentInner>
+        </StyledAlertContent>
+      </AlertDialogPrimitive.Portal>
+    );
+  },
+);
 
 AlertContent.displayName = 'AlertContent';
 

--- a/packages/ui/src/components/Alert/Alert.tsx
+++ b/packages/ui/src/components/Alert/Alert.tsx
@@ -1,58 +1,65 @@
-import * as AlertDialog from '@radix-ui/react-alert-dialog';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 import { Flex } from 'layouts';
 import React from 'react';
+import { CSSProp } from 'stitches.config';
 
 import { Button } from '../Button';
 import { Text } from '../Text';
-import * as Styled from './Alert.styled';
+import { StyledAlertContent, StyledAlertContentInner, StyledAlertOverlay } from './Alert.styled';
 
-export interface AlertProps {
-  title: React.ReactNode;
-  description: React.ReactNode;
-  actionLabel?: React.ReactNode;
-  cancelLabel?: React.ReactNode;
-  onAction?: React.MouseEventHandler<HTMLButtonElement>;
-}
+type AlertDialogPrimitivePrimitiveProps = React.ComponentProps<typeof AlertDialogPrimitive.Content>;
+type AlertContentProps = AlertDialogPrimitivePrimitiveProps &
+  CSSProp & {
+    title: React.ReactNode;
+    description: React.ReactNode;
+    actionLabel?: React.ReactNode;
+    cancelLabel?: React.ReactNode;
+    onAction?: React.MouseEventHandler<HTMLButtonElement>;
+  };
 
-const Alert = React.forwardRef<React.ElementRef<typeof Styled.Content>, AlertProps>(
-  ({ title, description, actionLabel = '확인', cancelLabel = '취소', onAction }, forwardedRef) => {
-    return (
-      <AlertDialog.Portal>
-        <Styled.Overlay />
-        <Styled.Content ref={forwardedRef}>
-          <Styled.ContentContainer>
-            <AlertDialog.Title asChild>
-              <Text as="h2" weight="bold" size="xl" css={{ marginBottom: '$2' }}>
-                {title}
-              </Text>
-            </AlertDialog.Title>
-            <AlertDialog.Description asChild>
-              <Text as="p" variant="variant" css={{ marginBottom: '$4' }}>
-                {description}
-              </Text>
-            </AlertDialog.Description>
-            <Flex spacingX={4}>
-              <AlertDialog.Action asChild onClick={onAction}>
-                <Button variant="primary" size="lg" fullWidth>
-                  {actionLabel}
-                </Button>
-              </AlertDialog.Action>
-              <AlertDialog.Cancel asChild>
-                <Button size="lg" fullWidth>
-                  {cancelLabel}
-                </Button>
-              </AlertDialog.Cancel>
-            </Flex>
-          </Styled.ContentContainer>
-        </Styled.Content>
-      </AlertDialog.Portal>
-    );
-  },
-);
-
-Alert.displayName = 'Alert';
-
-export default Object.assign(Alert, {
-  Root: AlertDialog.Root,
-  Trigger: AlertDialog.Trigger,
+const AlertContent = React.forwardRef<
+  React.ElementRef<typeof StyledAlertContent>,
+  AlertContentProps
+>(({ title, description, actionLabel = '확인', cancelLabel = '취소', onAction }, forwardedRef) => {
+  return (
+    <AlertDialogPrimitive.Portal>
+      <StyledAlertOverlay />
+      <StyledAlertContent ref={forwardedRef}>
+        <StyledAlertContentInner>
+          <AlertDialogPrimitive.Title asChild>
+            <Text as="h2" weight="bold" size="xl" css={{ marginBottom: '$2' }}>
+              {title}
+            </Text>
+          </AlertDialogPrimitive.Title>
+          <AlertDialogPrimitive.Description asChild>
+            <Text as="p" variant="variant" css={{ marginBottom: '$4' }}>
+              {description}
+            </Text>
+          </AlertDialogPrimitive.Description>
+          <Flex spacingX={4}>
+            <AlertDialogPrimitive.Action asChild onClick={onAction}>
+              <Button variant="primary" size="lg" fullWidth>
+                {actionLabel}
+              </Button>
+            </AlertDialogPrimitive.Action>
+            <AlertDialogPrimitive.Cancel asChild>
+              <Button size="lg" fullWidth>
+                {cancelLabel}
+              </Button>
+            </AlertDialogPrimitive.Cancel>
+          </Flex>
+        </StyledAlertContentInner>
+      </StyledAlertContent>
+    </AlertDialogPrimitive.Portal>
+  );
 });
+
+AlertContent.displayName = 'AlertContent';
+
+const Alert = {
+  Root: AlertDialogPrimitive.Root,
+  Trigger: AlertDialogPrimitive.Trigger,
+  Content: AlertContent,
+};
+
+export default Alert;

--- a/packages/ui/src/components/Alert/index.ts
+++ b/packages/ui/src/components/Alert/index.ts
@@ -1,2 +1,1 @@
 export { default as Alert } from './Alert';
-export { type AlertProps } from './Alert';

--- a/packages/ui/src/components/Alert/index.ts
+++ b/packages/ui/src/components/Alert/index.ts
@@ -1,0 +1,2 @@
+export { default as Alert } from './Alert';
+export { type AlertProps } from './Alert';

--- a/packages/ui/src/components/Dialog/Dialog.styled.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.styled.tsx
@@ -1,0 +1,140 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { styled, type VariantProps } from 'stitches.config';
+
+import { fadeIn, fadeInAndScaleUp } from '@/styles/keyframes';
+
+export const StyledDialogOverlay = styled(DialogPrimitive.Overlay, {
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  zIndex: '$modalBackdrop',
+  backdropFilter: 'blur(4px)',
+  backgroundColor: 'rgba(0,0,0,0.2)',
+  animation: `${fadeIn} $transitions$150 $transitions$easeIn`,
+});
+
+export const StyledDialogContent = styled(DialogPrimitive.Content, {
+  position: 'fixed',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+  zIndex: '$modal',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  '&:focus': {
+    outline: 'none',
+  },
+  variants: {
+    fullScreen: {
+      true: {
+        padding: 0,
+      },
+      false: {
+        paddingX: '$5',
+      },
+    },
+  },
+  defaultVariants: {
+    fullScreen: false,
+  },
+});
+
+export const StyledDialogContentInner = styled('div', {
+  position: 'relative',
+  zIndex: '$modal',
+  overflowY: 'auto',
+  width: '$full',
+  backgroundColor: '$surface',
+  animation: `${fadeInAndScaleUp} $transitions$150 $transitions$easeIn`,
+  variants: {
+    fullScreen: {
+      true: {
+        height: '$full',
+        width: '$full',
+      },
+      false: {
+        height: 'auto',
+        maxHeight: '80vh',
+        borderRadius: '$xl',
+      },
+    },
+    size: {
+      xs: {
+        maxWidth: '$xs',
+      },
+      sm: {
+        maxWidth: '$sm',
+      },
+      md: {
+        maxWidth: '$md',
+      },
+      lg: {
+        maxWidth: '$lg',
+      },
+      xl: {
+        maxWidth: '$xl',
+      },
+      '2xl': {
+        maxWidth: '$2xl',
+      },
+      '3xl': {
+        maxWidth: '$3xl',
+      },
+      '4xl': {
+        maxWidth: '$4xl',
+      },
+      '5xl': {
+        maxWidth: '$5xl',
+      },
+      '6xl': {
+        maxWidth: '$6xl',
+      },
+      '7xl': {
+        maxWidth: '$7xl',
+      },
+    },
+  },
+  defaultVariants: {
+    fullScreen: false,
+    size: 'lg',
+  },
+});
+
+export const StyledDialogHeader = styled('div', {
+  position: 'sticky',
+  top: 0,
+  left: 0,
+  right: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  flexDirection: 'row-reverse',
+  paddingTop: '$4',
+  paddingLeft: '$5',
+  paddingRight: '$4',
+  paddingBottom: '$3',
+  backgroundColor: '$surface',
+});
+
+export const StyledDialogBody = styled('div', {
+  paddingX: '$5',
+  paddingBottom: '$5',
+});
+
+export const StyleDialogCloseButton = styled(DialogPrimitive.Close, {
+  padding: '$1',
+  borderRadius: '$full',
+  color: '$onSurfaceVariant',
+  transitionProperty: '$transitions$colors',
+  transitionDelay: '$transitions$150',
+  transitionTimingFunction: '$transitions$easeIn',
+  '&:hover': {
+    backgroundColor: '$surfaceVariant',
+  },
+});
+
+export type DialogContentVariantProps = VariantProps<typeof StyledDialogContentInner>;

--- a/packages/ui/src/components/Dialog/Dialog.tsx
+++ b/packages/ui/src/components/Dialog/Dialog.tsx
@@ -1,0 +1,61 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import React from 'react';
+import { CSS } from 'stitches.config';
+
+import { CloseIcon } from '@triprint/icons';
+
+import { Text } from '../Text';
+import {
+  type DialogContentVariantProps,
+  StyledDialogBody,
+  StyledDialogContent,
+  StyledDialogContentInner,
+  StyledDialogHeader,
+  StyledDialogOverlay,
+  StyleDialogCloseButton,
+} from './Dialog.styled';
+
+type DialogContentPrimitiveProps = React.ComponentProps<typeof DialogPrimitive.Content>;
+type DialogContentProps = DialogContentPrimitiveProps & {
+  title?: string;
+  css?: CSS;
+};
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof StyledDialogContent>,
+  DialogContentProps & DialogContentVariantProps
+>(({ children, title, size = 'lg', fullScreen = false, ...props }, forwardedRef) => {
+  return (
+    <DialogPrimitive.Portal>
+      <StyledDialogOverlay />
+      <StyledDialogContent fullScreen={fullScreen} {...props} ref={forwardedRef}>
+        <StyledDialogContentInner fullScreen={fullScreen} size={size}>
+          <StyledDialogHeader>
+            <StyleDialogCloseButton>
+              <CloseIcon width={24} height={24} />
+            </StyleDialogCloseButton>
+            {title && (
+              <DialogPrimitive.Title>
+                <Text as="h2" size="xl" weight="bold">
+                  {title}
+                </Text>
+              </DialogPrimitive.Title>
+            )}
+          </StyledDialogHeader>
+          <StyledDialogBody>{children}</StyledDialogBody>
+        </StyledDialogContentInner>
+      </StyledDialogContent>
+    </DialogPrimitive.Portal>
+  );
+});
+
+DialogContent.displayName = 'DialogContent';
+
+const Dialog = {
+  Root: DialogPrimitive.Root,
+  Trigger: DialogPrimitive.Trigger,
+  CloseButton: DialogPrimitive.Close,
+  Content: DialogContent,
+};
+
+export default Dialog;

--- a/packages/ui/src/components/Dialog/index.ts
+++ b/packages/ui/src/components/Dialog/index.ts
@@ -1,0 +1,1 @@
+export { default as Dialog } from './Dialog';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Alert';
 export * from './Button';
 export * from './SocialButton';
 export * from './Text';

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Alert';
 export * from './Button';
+export * from './Dialog';
+export * from './Logo';
 export * from './SocialButton';
 export * from './Text';
-export * from './Logo';

--- a/packages/ui/src/stitches.config.ts
+++ b/packages/ui/src/stitches.config.ts
@@ -279,3 +279,5 @@ export const {
 });
 
 export type CSSProp = { css?: Stitches.CSS<typeof config> };
+export type CSS = Stitches.CSS<typeof config>;
+export type { VariantProps } from '@stitches/react';

--- a/packages/ui/src/styles/keyframes.ts
+++ b/packages/ui/src/styles/keyframes.ts
@@ -35,3 +35,32 @@ export const bounce = keyframes({
     animationTimingFunction: 'cubic-bezier(0, 0, 0.2, 1)',
   },
 });
+
+export const fadeIn = keyframes({
+  from: {
+    opacity: 0,
+  },
+  to: {
+    opacity: 1,
+  },
+});
+
+export const fadeOut = keyframes({
+  from: {
+    opacity: 1,
+  },
+  to: {
+    opacity: 0,
+  },
+});
+
+export const fadeInAndScaleUp = keyframes({
+  from: {
+    opacity: 0,
+    transform: 'scale(0.95)',
+  },
+  to: {
+    opacity: 1,
+    transform: 'scale(1)',
+  },
+});

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "@triprint/tsconfig/react-library.json",
   "compilerOptions": {
     "baseUrl": "src",
-    "declarationDir": "dist/types"
+    "declarationDir": "dist/types",
+    "paths": {
+      "@/styles/*": ["styles/*"]
+    }
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,7 +1121,7 @@
     core-js-pure "^3.25.1"
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.9", "@babel/runtime@^7.5.0", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
@@ -1677,6 +1677,161 @@
     loader-utils "^2.0.4"
     schema-utils "^3.0.0"
     source-map "^0.7.3"
+
+"@radix-ui/primitive@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.0.0.tgz#e1d8ef30b10ea10e69c76e896f608d9276352253"
+  integrity sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-alert-dialog@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.0.2.tgz#03ab5a419a750e757af225c2416c30b253dc7117"
+  integrity sha512-0MtxV53FaEEBOKRgyLnEqHZKKDS5BldQ9oUBsKVXWI5FHbl2jp35qs+0aJET+K5hJDsc40kQUzP7g+wC7tqrqA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dialog" "1.0.2"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-compose-refs@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz#37595b1f16ec7f228d698590e78eeed18ff218ae"
+  integrity sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-context@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.0.0.tgz#f38e30c5859a9fb5e9aa9a9da452ee3ed9e0aee0"
+  integrity sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-dialog@1.0.2", "@radix-ui/react-dialog@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.0.2.tgz#2d7a0bfed478afc40ed6fc78d0f53242af55284e"
+  integrity sha512-EKxxp2WNSmUPkx4trtWNmZ4/vAYEg7JkAfa1HKBUnaubw9eHzf1Orr9B472lJYaYz327RHDrd4R95fsw7VR8DA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-context" "1.0.0"
+    "@radix-ui/react-dismissable-layer" "1.0.2"
+    "@radix-ui/react-focus-guards" "1.0.0"
+    "@radix-ui/react-focus-scope" "1.0.1"
+    "@radix-ui/react-id" "1.0.0"
+    "@radix-ui/react-portal" "1.0.1"
+    "@radix-ui/react-presence" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-slot" "1.0.1"
+    "@radix-ui/react-use-controllable-state" "1.0.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
+"@radix-ui/react-dismissable-layer@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.2.tgz#f04d1061bddf00b1ca304148516b9ddc62e45fb2"
+  integrity sha512-WjJzMrTWROozDqLB0uRWYvj4UuXsM/2L19EmQ3Au+IJWqwvwq9Bwd+P8ivo0Deg9JDPArR1I6MbWNi1CmXsskg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.0"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+    "@radix-ui/react-use-escape-keydown" "1.0.2"
+
+"@radix-ui/react-focus-guards@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz#339c1c69c41628c1a5e655f15f7020bf11aa01fa"
+  integrity sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-focus-scope@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.1.tgz#faea8c25f537c5a5c38c50914b63722db0e7f951"
+  integrity sha512-Ej2MQTit8IWJiS2uuujGUmxXjF/y5xZptIIQnyd2JHLwtV0R2j9NRVoRj/1j/gJ7e3REdaBw4Hjf4a1ImhkZcQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-primitive" "1.0.1"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-id@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.0.0.tgz#8d43224910741870a45a8c9d092f25887bb6d11e"
+  integrity sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-portal@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.1.tgz#169c5a50719c2bb0079cf4c91a27aa6d37e5dd33"
+  integrity sha512-NY2vUWI5WENgAT1nfC6JS7RU5xRYBfjZVLq0HmgEN1Ezy3rk/UruMV4+Rd0F40PEaFC5SrLS1ixYvcYIQrb4Ig==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.1"
+
+"@radix-ui/react-presence@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.0.0.tgz#814fe46df11f9a468808a6010e3f3ca7e0b2e84a"
+  integrity sha512-A+6XEvN01NfVWiKu38ybawfHsBjWum42MRPnEuqPsBZ4eV7e/7K321B5VgYMPv3Xx5An6o1/l9ZuDBgmcmWK3w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+    "@radix-ui/react-use-layout-effect" "1.0.0"
+
+"@radix-ui/react-primitive@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz#c1ebcce283dd2f02e4fbefdaa49d1cb13dbc990a"
+  integrity sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-slot" "1.0.1"
+
+"@radix-ui/react-slot@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.0.1.tgz#e7868c669c974d649070e9ecbec0b367ee0b4d81"
+  integrity sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.0"
+
+"@radix-ui/react-use-callback-ref@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz#9e7b8b6b4946fe3cbe8f748c82a2cce54e7b6a90"
+  integrity sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+
+"@radix-ui/react-use-controllable-state@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz#a64deaafbbc52d5d407afaa22d493d687c538b7f"
+  integrity sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-use-escape-keydown@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.2.tgz#09ab6455ab240b4f0a61faf06d4e5132c4d639f6"
+  integrity sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-use-callback-ref" "1.0.0"
+
+"@radix-ui/react-use-layout-effect@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz#2fc19e97223a81de64cd3ba1dc42ceffd82374dc"
+  integrity sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
 
 "@rollup/pluginutils@^4.1.2", "@rollup/pluginutils@^4.2.1":
   version "4.2.1"
@@ -3545,6 +3700,13 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+aria-hidden@^1.1.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.2.tgz#8c4f7cc88d73ca42114106fdf6f47e68d31475b8"
+  integrity sha512-6y/ogyDTk/7YAe91T3E2PR1ALVKyM2QbTio5HwM+N1Q6CMlCKhvClyIjkckBswa0f2xJhjsfzIGa1yVSe1UMVA==
+  dependencies:
+    tslib "^2.0.0"
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -4944,6 +5106,11 @@ detab@2.0.4:
   dependencies:
     repeat-string "^1.5.4"
 
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
+
 detect-package-manager@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/detect-package-manager/-/detect-package-manager-2.0.1.tgz#6b182e3ae5e1826752bfef1de9a7b828cffa50d8"
@@ -6337,6 +6504,11 @@ get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@
     has "^1.0.3"
     has-symbols "^1.0.3"
 
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -6984,6 +7156,13 @@ interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+invariant@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
+  integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
+  dependencies:
+    loose-envify "^1.0.0"
 
 ip@^2.0.0:
   version "2.0.0"
@@ -7763,7 +7942,7 @@ lodash@4.17.21, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -9364,6 +9543,34 @@ react-refresh@^0.14.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.0.tgz#4e02825378a5f227079554d4284889354e5f553e"
   integrity sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==
 
+react-remove-scroll-bar@^2.3.3:
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
+  integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
+  dependencies:
+    react-style-singleton "^2.2.1"
+    tslib "^2.0.0"
+
+react-remove-scroll@2.5.5:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz#1e31a1260df08887a8a0e46d09271b52b3a37e77"
+  integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-style-singleton@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.1.tgz#f99e420492b2d8f34d38308ff660b60d0b1205b4"
+  integrity sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==
+  dependencies:
+    get-nonce "^1.0.0"
+    invariant "^2.2.4"
+    tslib "^2.0.0"
+
 react@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -10701,7 +10908,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.4.0:
+tslib@^2.0.0, tslib@^2.0.1, tslib@^2.0.3, tslib@^2.1.0, tslib@^2.4.0:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
@@ -11042,6 +11249,21 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-callback-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.0.tgz#772199899b9c9a50526fedc4993fc7fa1f7e32d5"
+  integrity sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.2.tgz#2f43126ba2d7d7e117aa5855e5d8f0276dfe73c2"
+  integrity sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 use-sync-external-store@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
## 📝 세부사항

- Alert 및 Dialog 컴포넌트 추가
- Alert 컴포넌트: 사용자에게 확인을 요구하는 작업을 할 때 사용 (`window.confirm`과 같은 역할)
- Dialog 컴포넌트: 기존 모달과 같이 새로운 창을 띄워서 작업할 때 사용
- `@radix-ui/react-dialog`, `@radix-ui/react-alert-dialog` 의존성 추가

## 📗 참고사항

- 지금은 Compound Component Concept과 다르게 Props를 통한 title과 같은 옵션들을 사용하는데 이부분에 대해서 고민해 볼 필요성이 있습니다.
- 추후에 `Dialog.Header`, `Dialog.Body`, `Dialog.Footer`와 같은 형식으로 Compound Component Concept를 따르는 것도 고려중입니다.
- [Storybook](https://63a1c23a82aa552f0147d4da-doyqftpebx.chromatic.com/?path=/story/components-alert--base)

## 📎 관련 이슈

close #24
